### PR TITLE
Removed from-chemistry from catalog file to always load it from web.

### DIFF
--- a/catalog-v001.xml
+++ b/catalog-v001.xml
@@ -3,6 +3,5 @@
     <group id="Folder Repository, directory=, recursive=true, Auto-Update=false, version=2" prefer="public" xml:base="">
         <uri name="http://emmo.info/crystallography/0.0.1/crystallography" uri="./crystallography.ttl"/>
         <uri name="http://emmo.info/emmo-inferred/1.0.0-beta" uri="https://emmo-repo.github.io/versions/1.0.0-beta/emmo-inferred.ttl"/>
-        <uri name="https://raw.githubusercontent.com/emmo-repo/domain-crystallography/master/from-chemistry.ttl" uri="from-chemistry.ttl"/>
     </group>
 </catalog>


### PR DESCRIPTION
For some reason Protege requires this...