### PR TITLE
Removed --ignore-namespace in emmocheck as imported emmo is not checked

### DIFF
--- a/.github/workflows/ci_emmocheck.yml
+++ b/.github/workflows/ci_emmocheck.yml
@@ -26,4 +26,4 @@ jobs:
 
     - name: Check EMMO
       run: |
-        emmocheck --ignore-namespace emmo --verbose crystallography.ttl
+        emmocheck --verbose crystallography.ttl


### PR DESCRIPTION
There is no reason to ignore emmo since we are not checking the imported emmo-inferred. Furthermore syntax for the test if the imported ontology was to be tested should have been

emmocheck --verbose --check-importeed --ignore-namespace http://emmo.info/emmo-inferred/ crystallography.ttl