### PR TITLE
Removed equivalence between cif direct part relations and EMMO hasSpatialDirectPart 

### DIFF
--- a/crystallography.ttl
+++ b/crystallography.ttl
@@ -77,14 +77,6 @@ owl:qualifiedCardinality rdf:type owl:AnnotationProperty .
 #    Object Properties
 #################################################################
 
-###  http://emmo.info/domain-crystallography/cif_top#hasSpatialDirectPart
-<http://emmo.info/domain-crystallography/cif_top#hasSpatialDirectPart> owl:equivalentProperty emmo:EMMO_b2282816_b7a3_44c6_b2cb_3feff1ceb7fe .
-
-
-###  http://emmo.info/domain-crystallography/cif_top#hasSpatialPart
-<http://emmo.info/domain-crystallography/cif_top#hasSpatialPart> owl:equivalentProperty emmo:EMMO_f68030be_94b8_4c61_a161_886468558054 .
-
-
 ###  http://emmo.info/emmo#EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0
 emmo:EMMO_8ef3cd6d_ae58_4a8d_9fc0_ad8f49015cd0 rdf:type owl:ObjectProperty .
 


### PR DESCRIPTION
Removed equivalence between cif direct part relations and EMMO hasSpatialDirectPart because since the CIF ontology no longer not defines direct parthood relations.

Furthermore, it turns out that FaCT++ does not cope with owl:equivalentProperty relations. For future alignment we should use rdfs:subPropertyOf instead

